### PR TITLE
Fix wrapping around multi-byte Unicode spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 UTF-8 Grapheme Cluster Safe Word Wrapping / Line Splitting for Go based on number of bytes.
 
-This library wraps text without breaking UTF-8 grapheme clusters. It operates on byte count, not runes. It breaks on whitespace first. If a word is too long, it breaks between grapheme clusters. It never splits emojis like 👩‍👩‍👧‍👧 or characters with combining marks.
+This library wraps text without breaking UTF-8 grapheme clusters. It operates on byte count, not runes. It prefers breakable whitespace, then other Unicode whitespace, before breaking between grapheme clusters. It never splits emojis like 👩‍👩‍👧‍👧 or characters with combining marks.
 
 This is useful for protocols where message size is limited by bytes.
 

--- a/wordwrap.go
+++ b/wordwrap.go
@@ -22,8 +22,16 @@ type charPos struct {
 	pos, size int
 }
 
+func isBreakableSpace(r rune) bool {
+	switch r {
+	case '\u00a0', '\u2007', '\u202f': // Non-breaking, figure, and narrow non-breaking spaces.
+		return false
+	}
+	return unicode.IsSpace(r)
+}
+
 // SplitString splits a string at a certain number of bytes without breaking
-// UTF-8 runes, grapheme clusters, and on Unicode space characters when possible.
+// UTF-8 runes or grapheme clusters, and prefers breakable Unicode spaces when possible.
 //
 // SplitString returns an ErrGraphemeClusterTooLarge error if it is forced to split
 // a grapheme cluster that is larger than the byte limit.
@@ -34,7 +42,8 @@ func SplitString(s string, byteLimit uint) ([]string, error) {
 	var workingLine strings.Builder
 	finishedLines := []string{}
 
-	spacePos := charPos{}
+	preferredSpacePos := charPos{}
+	fallbackSpacePos := charPos{}
 	lastPos := charPos{}
 
 	// Use grapheme cluster iterator
@@ -45,19 +54,35 @@ func SplitString(s string, byteLimit uint) ([]string, error) {
 
 		workingLine.WriteString(cluster)
 
-		// Check if the cluster contains a space (check first rune)
+		// Track breakable spaces separately so they are always preferred.
 		firstRune, _ := utf8.DecodeRuneInString(cluster)
-		if unicode.IsSpace(firstRune) {
-			spacePos = charPos{workingLine.Len(), clusterSize}
+		if unicode.IsSpace(firstRune) && workingLine.Len() <= int(byteLimit) {
+			fallbackSpacePos = charPos{workingLine.Len(), clusterSize}
+			if isBreakableSpace(firstRune) {
+				preferredSpacePos = fallbackSpacePos
+			}
 		}
 
 		if workingLine.Len() >= int(byteLimit) {
-			if spacePos.size > 0 {
+			breakPos := preferredSpacePos
+			if breakPos.size == 0 {
+				breakPos = fallbackSpacePos
+			}
+
+			if breakPos.size > 0 {
 				line := workingLine.String()
-				finishedLines = append(finishedLines, line[0:spacePos.pos])
+				finishedLines = append(finishedLines, line[0:breakPos.pos])
 
 				workingLine.Reset()
-				workingLine.WriteString(line[spacePos.pos:])
+				workingLine.WriteString(line[breakPos.pos:])
+
+				// Preserve a non-breaking-space fallback that remains on the next line.
+				preferredSpacePos = charPos{}
+				if fallbackSpacePos.pos > breakPos.pos {
+					fallbackSpacePos.pos -= breakPos.pos
+				} else {
+					fallbackSpacePos = charPos{}
+				}
 			} else {
 				if workingLine.Len() > int(byteLimit) {
 					// If there's no valid break point (lastPos.pos is 0),
@@ -67,20 +92,22 @@ func SplitString(s string, byteLimit uint) ([]string, error) {
 					}
 					line := workingLine.String()
 					finishedLines = append(finishedLines, line[0:lastPos.pos])
-					
+
 					workingLine.Reset()
 					workingLine.WriteString(line[lastPos.pos:])
 				} else {
 					finishedLines = append(finishedLines, workingLine.String())
 					workingLine.Reset()
 				}
+
+				preferredSpacePos = charPos{}
+				fallbackSpacePos = charPos{}
 			}
 
 			if len(finishedLines[len(finishedLines)-1]) > int(byteLimit) {
 				return nil, ErrGraphemeClusterTooLarge
 			}
 
-			spacePos = charPos{}
 		}
 
 		lastPos = charPos{workingLine.Len(), clusterSize}

--- a/wordwrap_test.go
+++ b/wordwrap_test.go
@@ -130,6 +130,70 @@ func TestSplitString(t *testing.T) {
 	}
 }
 
+func TestSplitStringUnicodeSpaces(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		output  []string
+		bytelim uint
+	}{
+		{
+			name:    "non-breaking space is used as a fallback break",
+			input:   "a\u00a0bc",
+			output:  []string{"a\u00a0", "bc"},
+			bytelim: 4,
+		},
+		{
+			name:    "figure space is used as a fallback break",
+			input:   "a\u2007bc",
+			output:  []string{"a\u2007", "bc"},
+			bytelim: 5,
+		},
+		{
+			name:    "narrow non-breaking space is used as a fallback break",
+			input:   "a\u202fbc",
+			output:  []string{"a\u202f", "bc"},
+			bytelim: 5,
+		},
+		{
+			name:    "breakable Unicode space creates a preferred break",
+			input:   "a\u2003bc",
+			output:  []string{"a\u2003", "bc"},
+			bytelim: 5,
+		},
+		{
+			name:    "breakable space is preferred over a non-breaking-space fallback",
+			input:   "a\u00a0b cde",
+			output:  []string{"a\u00a0b ", "cde"},
+			bytelim: 6,
+		},
+		{
+			name:    "fallback is retained after a preferred break",
+			input:   "a \u00a0bcd",
+			output:  []string{"a ", "\u00a0", "bcd"},
+			bytelim: 5,
+		},
+		{
+			name:    "non-breaking space is not reported as oversized when it fits alone",
+			input:   "a\u00a0",
+			output:  []string{"a", "\u00a0"},
+			bytelim: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := SplitString(test.input, test.bytelim)
+			if err != nil {
+				t.Fatalf("SplitString(%#v, %d) returned unexpected error: %v", test.input, test.bytelim, err)
+			}
+			if !reflect.DeepEqual(actual, test.output) {
+				t.Errorf("SplitString(%#v, %d) = %#v; want %#v", test.input, test.bytelim, actual, test.output)
+			}
+		})
+	}
+}
+
 func TestSplitStringError(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -185,6 +249,11 @@ func TestSplitStringError(t *testing.T) {
 			name:    "Vietnamese combining marks too large",
 			input:   "ệ",
 			bytelim: 2, // ệ is 3 bytes
+		},
+		{
+			name:    "Non-breaking space too large",
+			input:   "\u00a0",
+			bytelim: 1, // Non-breaking space is 2 bytes
 		},
 	}
 


### PR DESCRIPTION
## Summary

- prefer breakable Unicode whitespace as a wrapping point
- fall back to other Unicode whitespace before splitting at a grapheme boundary
- preserve fallback candidates after a preferred break and document the policy
- add regression coverage for preferred, fallback, and oversized-space cases

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`